### PR TITLE
Implement for conversion between machine integers

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "try_from"
-version = "0.2.0"
+version = "0.2.1"
 authors = ["Derek Williams <derek@fyrie.net>"]
 description = "TryFrom and TryInto traits for failable conversions that return a Result."
 repository = "https://github.com/derekjw/try_from"

--- a/src/int.rs
+++ b/src/int.rs
@@ -1,0 +1,219 @@
+// Conversion between machine integers.
+
+use std::{u8, u16, u32, u64, usize, i8, i16, i32, i64, isize};
+use std::error::Error;
+use std::fmt::{self, Display, Formatter};
+use std::mem;
+
+use ::{TryFrom, Void};
+
+/// Error which occurs when conversion from one integer type to another fails.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum TryFromIntError {
+    Overflow,
+    Underflow,
+}
+
+impl TryFromIntError {
+    fn as_str (self) -> &'static str {
+        match self {
+            TryFromIntError::Overflow => "integer overflow",
+            TryFromIntError::Underflow => "integer underflow",
+        }
+    }
+}
+
+impl Display for TryFromIntError {
+    fn fmt (&self, n: &mut Formatter) -> fmt::Result {
+        n.write_str(self.as_str())
+    }
+}
+
+impl Error for TryFromIntError {
+    fn description (&self) -> &str { self.as_str() }
+}
+
+macro_rules! impl_infallible {
+    { $($t:ident from $($f:ident),*;)* } => { $($(
+        impl TryFrom<$f> for $t {
+            type Err = Void;
+            fn try_from (n: $f) -> Result<$t, Void> { Ok(n as $t) }
+        }
+    )*)* };
+}
+
+impl_infallible! {
+    u8 from u8;
+    u16 from u8, u16;
+    u32 from u8, u16, u32;
+    u64 from u8, u16, u32, u64, usize;
+    usize from u8, u16, u32, usize;
+    i8 from i8;
+    i16 from u8, i8, i16;
+    i32 from u8, u16, i8, i16, i32;
+    i64 from u8, u16, u32, i8, i16, i32, i64, isize;
+    isize from u8, u16, i8, i16, i32, isize;
+}
+
+#[test]
+fn test_infallible () {
+    assert_eq!(u64::try_from(usize::MAX), Ok(usize::MAX as u64));
+}
+
+macro_rules! impl_unsigned_from_unsigned {
+    { $($t:ident from $($f:ident),*;)* } => { $($(
+        impl TryFrom<$f> for $t {
+            type Err = TryFromIntError;
+
+            fn try_from (n: $f) -> Result<$t, TryFromIntError> {
+                if mem::size_of::<$f>() > mem::size_of::<$t>() && n > $t::MAX as $f {
+                    Err(TryFromIntError::Overflow)
+                } else {
+                    Ok(n as $t)
+                }
+            }
+        }
+    )*)* };
+}
+
+impl_unsigned_from_unsigned! {
+    u8 from u16, u32, u64, usize;
+    u16 from u32, u64, usize;
+    u32 from u64, usize;
+    usize from u64;
+}
+
+#[test]
+fn test_unsigned_from_unsigned () {
+    assert_eq!(u8::try_from(0xffu16), Ok(0xffu8));
+    assert_eq!(u8::try_from(0x100u16), Err(TryFromIntError::Overflow));
+
+    if cfg!(target_pointer_width = "32") {
+        assert_eq!(u32::try_from(usize::MAX), Ok(u32::MAX));
+        assert_eq!(usize::try_from(u64::MAX), Err(TryFromIntError::Overflow));
+    } else if cfg!(target_pointer_width = "64") {
+        assert_eq!(u32::try_from(usize::MAX), Err(TryFromIntError::Overflow));
+        assert_eq!(usize::try_from(u64::MAX), Ok(usize::MAX));
+    }
+}
+
+macro_rules! impl_unsigned_from_signed {
+    { $($t:ident from $($f:ident),*;)* } => { $($(
+        impl TryFrom<$f> for $t {
+            type Err = TryFromIntError;
+
+            fn try_from (n: $f) -> Result<$t, TryFromIntError> {
+                if n < 0 {
+                    Err(TryFromIntError::Underflow)
+                } else if mem::size_of::<$f>() > mem::size_of::<$t>() && n > $t::MAX as $f {
+                    Err(TryFromIntError::Overflow)
+                } else {
+                    Ok(n as $t)
+                }
+            }
+        }
+    )*)* };
+}
+
+impl_unsigned_from_signed! {
+    u8 from i8, i16, i32, i64, isize;
+    u16 from i8, i16, i32, i64, isize;
+    u32 from i8, i16, i32, i64, isize;
+    u64 from i8, i16, i32, i64, isize;
+    usize from i8, i16, i32, i64, isize;
+}
+
+#[test]
+fn test_unsigned_from_signed () {
+    assert_eq!(u8::try_from(0i16), Ok(0u8));
+    assert_eq!(u8::try_from(-1i16), Err(TryFromIntError::Underflow));
+    assert_eq!(u8::try_from(256i16), Err(TryFromIntError::Overflow));
+
+    if cfg!(target_pointer_width = "32") {
+        assert_eq!(u32::try_from(isize::MAX), Ok(0x7fff_ffffu32));
+        assert_eq!(usize::try_from(i64::MAX), Err(TryFromIntError::Overflow));
+    } else if cfg!(target_pointer_width = "64") {
+        assert_eq!(u32::try_from(isize::MAX), Err(TryFromIntError::Overflow));
+        assert!(usize::try_from(i64::MAX).unwrap() > 0xffff_ffffusize);
+    }
+}
+
+macro_rules! impl_signed_from_unsigned {
+    { $($t:ident from $($f:ident),*;)* } => { $($(
+        impl TryFrom<$f> for $t {
+            type Err = TryFromIntError;
+
+            fn try_from (n: $f) -> Result<$t, TryFromIntError> {
+                if mem::size_of::<$f>() >= mem::size_of::<$t>() && n > $t::MAX as $f {
+                    Err(TryFromIntError::Overflow)
+                } else {
+                    Ok(n as $t)
+                }
+            }
+        }
+    )*)* };
+}
+
+impl_signed_from_unsigned! {
+    i8 from u8, u16, u32, u64, usize;
+    i16 from u16, u32, u64, usize;
+    i32 from u32, u64, usize;
+    i64 from u64, usize;
+    isize from u32, u64, usize;
+}
+
+#[test]
+fn test_signed_from_unsigned () {
+    assert_eq!(i8::try_from(0x7fu8), Ok(0x7fi8));
+    assert_eq!(i8::try_from(0x80u8), Err(TryFromIntError::Overflow));
+
+    if cfg!(target_pointer_width = "32") {
+        assert_eq!(i64::try_from(usize::MAX), Ok(0xffff_ffffi64));
+        assert_eq!(isize::try_from(0x8000_0000u64), Err(TryFromIntError::Overflow));
+    } else if cfg!(target_pointer_width = "64") {
+        assert_eq!(i64::try_from(usize::MAX), Err(TryFromIntError::Overflow));
+        assert!(isize::try_from(0x8000_0000u64).unwrap() > 0x7fff_ffff);
+    }
+}
+
+macro_rules! impl_signed_from_signed {
+    { $($t:ident from $($f:ident),*;)* } => { $($(
+        impl TryFrom<$f> for $t {
+            type Err = TryFromIntError;
+
+            fn try_from (n: $f) -> Result<$t, TryFromIntError> {
+                if mem::size_of::<$f>() > mem::size_of::<$t>() {
+                    if n > $t::MAX as $f {
+                        return Err(TryFromIntError::Overflow);
+                    } else if n < $t::MIN as $f {
+                        return Err(TryFromIntError::Underflow);
+                    }
+                }
+                Ok(n as $t)
+            }
+        }
+    )*)* };
+}
+
+impl_signed_from_signed! {
+    i8 from i16, i32, i64, isize;
+    i16 from i32, i64, isize;
+    i32 from i64, isize;
+    isize from i64;
+}
+
+#[test]
+fn test_signed_from_signed () {
+    assert_eq!(i8::try_from(127i16), Ok(127i8));
+    assert_eq!(i8::try_from(128i16), Err(TryFromIntError::Overflow));
+    assert_eq!(i8::try_from(-128i16), Ok(-128i8));
+    assert_eq!(i8::try_from(-129i16), Err(TryFromIntError::Underflow));
+
+    if cfg!(target_pointer_width = "32") {
+        assert_eq!(i32::try_from(isize::MAX), Ok(i32::MAX));
+        assert_eq!(isize::try_from(i64::MAX), Err(TryFromIntError::Overflow));
+    } else if cfg!(target_pointer_width = "64") {
+        assert_eq!(i32::try_from(isize::MAX), Err(TryFromIntError::Overflow));
+        assert!(isize::try_from(i64::MAX).unwrap() > 0x7fff_ffffisize);
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,9 @@
 use std::str::FromStr;
 
+mod int;
+
+pub use int::TryFromIntError;
+
 pub trait TryFrom<T>: Sized {
     type Err;
     fn try_from(T) -> Result<Self, Self::Err>;
@@ -46,3 +50,8 @@ mod tests {
         assert_eq!(result.unwrap(), 3)
     }
 }
+
+/// Error type used when conversion is infallible.
+/// The never type (`!`) will replace this when it is available in stable Rust.
+#[derive(Debug, Eq, PartialEq)]
+pub enum Void {}


### PR DESCRIPTION
All combinations from and to the 10 integer types are implemented. Tests were written for target dependent (e.g. `usize` to `u32`) and target independent (e.g. `u64` to `u32`) conversions, and all passed on both 32 and 64 bit builds. I added a `Void` type which can be replaced with the never type (`!`) once that becomes available in stable Rust.