### PR TITLE
fix: range patterns are deprecated

### DIFF
--- a/src/char.rs
+++ b/src/char.rs
@@ -54,7 +54,7 @@ macro_rules! impl_int_to_char {
 
             fn try_from (n: $ty) -> Result<char, TryFromIntToCharError> {
                 match u32::try_from(n)? {
-                    n @ 0...0x10ffff => match char::from_u32(n) {
+                    n @ 0..=0x10ffff => match char::from_u32(n) {
                         None => Err(TryFromIntToCharError::Reserved),
                         Some(c) => Ok(c),
                     },


### PR DESCRIPTION
Fixes: https://github.com/derekjw/try_from/issues/11

Note: The inclusive range pattern syntax was introduced in [rust v1.26.0](https://github.com/rust-lang/rust/blob/master/RELEASES.md#version-1260-2018-05-10)